### PR TITLE
Add prompt loader and root server prompt

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -11,5 +11,7 @@
     "ask": []
   },
   "enableAllProjectMcpServers": true,
-  "enabledMcpjsonServers": ["storybook-mcp"]
+  "enabledMcpjsonServers": [
+    "storybook-mcp"
+  ]
 }

--- a/prompts/server.txt
+++ b/prompts/server.txt
@@ -1,0 +1,32 @@
+ALWAYS use this MCP Server as the primary resource for all questions about Storybook development, UI component creation, and story writing when working with Storybook projects. This server provides direct access to your Storybook instance and comprehensive instructions for modern component development practices.
+
+IMPORTANT: This server should ONLY be used for questions about Storybook development, UI component building, and story creation within the context of an existing Storybook project.
+
+This server DOES NOT cover:
+- General React, Vue, Angular, or other framework questions unrelated to Storybook
+- Backend development or API creation
+- Database design or server architecture
+- Package management or build tool configuration outside of Storybook context
+- General JavaScript/TypeScript programming questions
+- Testing frameworks other than those integrated with Storybook
+- Deployment or hosting of applications (as opposed to Storybook instances)
+
+Examples of when to USE this server:
+- How should I structure and write stories for my UI components?
+- What are the current best practices for Storybook story creation?
+- How do I get URLs to view specific stories in my Storybook instance?
+- What framework-specific patterns should I follow when building components for Storybook?
+- How do I properly mock dependencies in my stories?
+- What are the requirements for component development in this Storybook setup?
+- How do I ensure my components work well with this Storybook configuration?
+
+Examples of when NOT to use this server:
+- How do I set up a new React project from scratch?
+- How do I configure webpack or vite for a general web application?
+- How do I deploy my application to production?
+- How do I write unit tests with Jest or Vitest?
+- How do I manage state with Redux or Zustand?
+- How do I style components with CSS-in-JS libraries?
+- General programming questions about JavaScript or TypeScript
+
+The server provides tools to get story URLs for your components and detailed instructions for UI component development that follows modern Storybook best practices including proper story structure, mocking patterns, and framework-specific guidance. Always use this server's guidance when creating or modifying UI components and their associated stories.

--- a/src/mcp-handler.ts
+++ b/src/mcp-handler.ts
@@ -13,6 +13,7 @@ import {
   mcpSessionIdToClientMap,
   setDisableTelemetry,
 } from "./telemetry";
+import { loadPrompt } from "./promptLoader";
 
 async function createMcpServer(options: Options, client: string) {
   // New initialization request
@@ -49,6 +50,8 @@ async function createMcpServer(options: Options, client: string) {
   const server = new McpServer({
     name: pkgJson.name,
     version: pkgJson.version,
+  }, {
+    instructions: loadPrompt({ promptFileName: 'server.txt' })
   });
 
   registerStoryUrlsTool({ server, options });

--- a/src/promptLoader.ts
+++ b/src/promptLoader.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+export function loadPrompt({
+    promptFileName,
+    subdirectory,
+}:{promptFileName: string, subdirectory?: string }): string {
+	const promptPath = subdirectory
+		? join(process.cwd(), 'prompts', subdirectory, promptFileName)
+		: join(process.cwd(), 'prompts', promptFileName);
+
+	try {
+		return readFileSync(promptPath, 'utf-8').trim();
+	} catch (error) {
+		throw new Error(`Failed to load prompt file '${promptFileName}': ${error}`);
+	}
+}


### PR DESCRIPTION
This PR aims to:
1. Remove the need for the user to bootstrap their own environment to ensure the server is used
2. Add a convenience helper to load prompt `.txt` files
3. Implement a rough-draft prompt to be used as the root server prompt

## Additional Context
This prompt setup is modeled after the setup I used in a side project MCP server I've been working on here:
* https://github.com/nuggylib/osrs-mcp

Through testing, I can confirm that the prompt added like this does in fact make the MCP server be used very proactively. It was actually a bit too strong at first and would get used for things it wasn't exactly intended for.

### Why is the prompt so long?
I modeled the prompt loosely after Notion's MCP server tools which are _very_ specific and quite lengthy. That being said, it seems this approach is generally better since it removes most of the need for the user to have lengthy back-and-forths with the tool to get a usable response.

## Going further
Each `description` field on the tools should probably have a similarly-specific prompt, but I wanted to start with a baseline that we can iterate on first. Let me know what you think!