### PR TITLE
Makes it available even in versions below 9.12.0

### DIFF
--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -1,5 +1,5 @@
-import { logger } from "storybook/internal/node-logger";
 import { telemetry } from "storybook/internal/telemetry";
+import { logger } from "./tools/logger";
 
 export async function collectTelemetry({
   event,

--- a/src/tools/get-story-urls.ts
+++ b/src/tools/get-story-urls.ts
@@ -2,9 +2,9 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import path from "node:path";
 import { storyNameFromExport } from "storybook/internal/csf";
 import type { Options, StoryIndex } from "storybook/internal/types";
-import { logger } from "storybook/internal/node-logger";
 import z from "zod";
 import { collectTelemetry } from "../telemetry";
+import { logger } from "./logger";
 
 const inputStoriesSchema = z.array(
   z.object({

--- a/src/tools/get-ui-building-instructions.ts
+++ b/src/tools/get-ui-building-instructions.ts
@@ -3,7 +3,7 @@ import { GET_STORY_URLS_TOOL_NAME } from "./get-story-urls";
 import { collectTelemetry } from "../telemetry";
 import uiInstructionsTemplate from "../ui-building-instructions.md";
 import type { Options } from "storybook/internal/types";
-import { logger } from "storybook/internal/node-logger";
+import { logger } from "./logger";
 
 export function registerUIBuildingTool({
   server,

--- a/src/tools/logger.ts
+++ b/src/tools/logger.ts
@@ -1,0 +1,21 @@
+import { logger as storybookLogger } from "storybook/internal/node-logger";
+
+/**
+ * Safe logger wrapper that provides fallback for Storybook < 9.12.0
+ * In those versions, the logger object does not have `debug` method.
+ */
+export const logger = {
+  ...storybookLogger,
+  debug: (...args: any[]): void => {
+    if (typeof storybookLogger.debug === "function") {
+      storybookLogger.debug(...args);
+    } else {
+      const joinedMessage = args
+        .map((arg) =>
+          typeof arg === "object" ? JSON.stringify(arg) : String(arg),
+        )
+        .join("\n");
+      storybookLogger.info(joinedMessage);
+    }
+  },
+};


### PR DESCRIPTION
## Related Issue

close: https://github.com/storybookjs/addon-mcp/issues/14

## Background

This mcp was unavailable in certain versions. (See the Related Issue for details.)
Upon my investigation, I discovered that storybook's v9.12.0 and later versions had added several methods to the logger, including `debug`.
This caused issues for users still using versions below 9.12.0, as the functionality did not work properly.

## What to do

To resolve this, I created a wrapper function that evaluates `logger.debug` at runtime and falls back to `logger.info` if the method is not available.
I then modified all instances of `logger.debug` to use this wrapper function instead.
